### PR TITLE
Workflow update to git version develop  

### DIFF
--- a/.github/workflows/developrelease.yml
+++ b/.github/workflows/developrelease.yml
@@ -11,6 +11,18 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Fetch all history for all tags and branches
+      run: git fetch --unshallow || true
+    - name: Install GitVersion
+      uses: gittools/actions/gitversion/setup@v0.9.4
+      with:
+          versionSpec: '5.3.x'
+    - name: Use GitVersion
+      id: gitversion # step id used as reference for output values
+      uses: gittools/actions/gitversion/execute@v0.9.4
+    - run: |
+        echo "NuGetVersion: ${{ steps.gitversion.outputs.NuGetVersionV2 }}"
+    - uses: actions/checkout@v2
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
@@ -27,7 +39,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
       with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
+        tag_name:  ${{ steps.gitversion.outputs.NuGetVersionV2 }}
+        release_name: Release  ${{ steps.gitversion.outputs.NuGetVersionV2 }}
         prerelease: true
     


### PR DESCRIPTION
Swaps from using a standard name for every merge to develop to use gitversion to add just use
 NuGetVersionV2 which by default should include beta on develop branch

Address https://github.com/Jandev/azurefunctions-sqlbinding/issues/13 
